### PR TITLE
Feature edit api only in 24hrs after creation 159968509

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,5 @@
+
+LOCAL_DB_URL= 
+TEST_DB_URL =
+DBNAME = 
+JWT_KEY = 

--- a/server/controllers/diarycontroller.js
+++ b/server/controllers/diarycontroller.js
@@ -63,17 +63,6 @@ class Diary {
 
   editDiary(req, res) {
 
-    const errorHandler = singleGetValidator(req.params.id);
-
-    if (errorHandler) {
-      return res.status(400).json({ error: errorHandler });
-    }
-
-    const check_error = dairyInput(req.body);
-    if (check_error) {
-      return res.status(400).json({error: check_error });
-    }
-
     diary_model.editADiary(req.db_user_id, req.params.id, req.body)
       .then(result => {
         if(result.rowCount === 0){
@@ -81,8 +70,8 @@ class Diary {
         }
         else{
           return res.status(200).json({ message: 'Diary Updated Successfully', diary: result.rows[0]});
-        }
         
+        }
       })
       .catch(err => {
         console.log(err);

--- a/server/middleware/editcheck.js
+++ b/server/middleware/editcheck.js
@@ -1,0 +1,63 @@
+import DbModels from "../models/dbhconnect";
+import { dairyInput, singleGetValidator } from '../helpers/diaryvalidator';
+
+let dbModels = new DbModels;
+
+
+
+let isEditable = (req, res, next) => {
+    const errorHandler = singleGetValidator(req.params.id);
+
+    if (errorHandler) {
+      return res.status(400).json({ error: errorHandler });
+    }
+
+    const check_error = dairyInput(req.body);
+    if (check_error) {
+      return res.status(400).json({error: check_error });
+    }
+
+    let db_user_id = req.db_user_id;
+    let input_diary_id = req.params.id;
+    let current_date = new Date();
+
+    const sql = `SELECT * FROM diaries WHERE user_id = $1 AND (diary_id = $2)`;
+
+    let param = [db_user_id, input_diary_id];
+    dbModels.pool.query(sql, param)
+    .then(result => {
+        if(result.rowCount < 1){
+            return res.status(404).json({error: 'Diary Not Found'});
+        }
+        themainEdit(db_user_id,input_diary_id, current_date, next);
+    })
+    .catch(err =>{
+        console.log(err, err)
+        return res.status(403).json({error: 'You cannot edit this diary content'});
+    });
+
+    let themainEdit = (db_user_id,input_diary_id, current_date, next) => {
+    
+        const date_sql = `SELECT * FROM diaries WHERE user_id = $1 AND (diary_id = $2 AND date_created > $3 ::date - interval '1 day')`;
+        let param2 = [db_user_id, input_diary_id, current_date];
+        dbModels.pool.query(date_sql, param2)
+    .then(result => {
+        if(result.rowCount > 0){
+            next();
+        }
+        else {
+            return res.status(403).json({error: 'You cannot edit this diary content'});
+        }
+    })
+    .catch(err =>{
+        console.log(err);
+    })
+
+
+}
+
+
+
+}
+
+export default isEditable;

--- a/server/models/diarymodel.js
+++ b/server/models/diarymodel.js
@@ -1,6 +1,7 @@
 
 import DbModels from "./dbhconnect";
 const dbModels = new DbModels;
+import date_created from './dbhconnect';
 
 
 class diaryModel{
@@ -19,12 +20,19 @@ class diaryModel{
     }
 
     addANewDiary(id, req_body){
+
+      let date_created = new Date();
+      
+      if (process.env.NODE_ENV === 'test') {
+        date_created.setDate(date_created.getDate() + 1);
+    }
+
       const user_id = id;
       const diary_title = req_body.diary_title;
       const diary_image = req_body.diary_image;
       const diary_body = req_body.diary_content;
-      const date_created = new Date;
-      const date_updated = new Date;
+     
+      const date_updated =  new Date();
 
 
       const sql = `INSERT INTO diaries(user_id, diary_title, diary_image, diary_content, date_created, date_updated ) 

--- a/server/routes/diaryroutes.js
+++ b/server/routes/diaryroutes.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import verifyToken from '../middleware/checkauth';
 import Diary from '../controllers/diarycontroller';
+import isEditable from '../middleware/editcheck';
+
 
 const router = express.Router();
 const diary = new Diary();
@@ -9,7 +11,7 @@ const diary = new Diary();
 router.get('/', verifyToken, diary.allDiaries);
 router.post('/', verifyToken, diary.addDiary);
 router.get('/:id',verifyToken, diary.getADiary);
-router.put('/:id', verifyToken, diary.editDiary);
+router.put('/:id', verifyToken, isEditable, diary.editDiary);
 router.delete('/:id', verifyToken, diary.deleteDiary);
 
 export default router;

--- a/server/tests/diaryvalidator.test.js
+++ b/server/tests/diaryvalidator.test.js
@@ -5,7 +5,7 @@ import {dairyInput, singleGetValidator} from '../helpers/diaryvalidator'
 describe('Diary Input Test', () => {
 
 
-    const short_title_input = {
+    const short_title_input =  {
         diary_title: 'to',
         diary_content: 'this is toy'
     }

--- a/server/tests/userdiaryapi.test.js
+++ b/server/tests/userdiaryapi.test.js
@@ -3,8 +3,6 @@ import app from '../../app';
 import assert from 'assert';
 import jwt from 'jsonwebtoken';
 
-import DbModel from '../models/dbhconnect';
-
 
 const path = "/api/v1/entries/";
 const request = supertest(app);


### PR DESCRIPTION
#### What does this PR do?
- implement feature which allow a user to only be able to edit a diary within 24 hours of creation
#### Description of Task to be completed?
- [x] write TDD test for the middleware
- [x] create middelware that check if diary can be edited
- [x] connect the middle ware to the api

#### How should this be manually tested?
- clone repo and run npm install etc
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
- story type - feature
- story title - User should only be able to edit a diary entry in 24 hours of creation
- story id - 159968509
#### Screenshots (if appropriate)
none

